### PR TITLE
Batch evaluation: crown the best challenger, not the fastest

### DIFF
--- a/eval_server.py
+++ b/eval_server.py
@@ -29,6 +29,7 @@ from pydantic import BaseModel
 from eval_torch import (
     R2, MultiGPUEvaluator, run_bootstrap_test, parse_gpu_ids,
     check_weight_norms,
+    compute_king_baseline, eval_challenger_against_baseline,
 )
 
 log = logging.getLogger("eval_server")
@@ -45,6 +46,8 @@ _king_hash: str | None = None
 _king_revision: str | None = None
 _eval_lock = threading.Lock()
 _evals: dict[str, dict] = {}
+_king_baseline: dict | None = None
+_king_baseline_key: str | None = None
 
 DEFAULT_BATCH_SIZE = int(os.environ.get("EVAL_BATCH_SIZE", "256"))
 DEFAULT_EVAL_N = int(os.environ.get("EVAL_N", "10000"))
@@ -102,6 +105,26 @@ class EvalRequest(BaseModel):
     n_bootstrap: int = DEFAULT_BOOTSTRAP_B
 
 
+class KingBaselineRequest(BaseModel):
+    king_repo: str
+    shard_key: str
+    seed_str: str
+    king_hash: str = ""
+    king_revision: str = ""
+    eval_n: int = DEFAULT_EVAL_N
+    seq_len: int = DEFAULT_SEQ_LEN
+    batch_size: int = DEFAULT_BATCH_SIZE
+
+
+class ChallengerEvalRequest(BaseModel):
+    challenger_repo: str
+    challenger_revision: str = ""
+    alpha: float = DEFAULT_ALPHA
+    delta: float = DEFAULT_DELTA
+    batch_size: int = DEFAULT_BATCH_SIZE
+    n_bootstrap: int = DEFAULT_BOOTSTRAP_B
+
+
 # ---------------------------------------------------------------------------
 # Model management
 # ---------------------------------------------------------------------------
@@ -109,12 +132,17 @@ class EvalRequest(BaseModel):
 def _ensure_king(repo: str, king_hash: str = "", revision: str = ""):
     """Load or reuse king evaluator. Reloads if repo, revision, or king_hash changed."""
     global _king_evaluator, _king_repo, _king_hash, _king_revision
+    global _king_baseline, _king_baseline_key
     if (_king_evaluator and _king_repo == repo
             and (not revision or _king_revision == revision)
             and (not king_hash or _king_hash == king_hash)):
         log.info("reusing cached king evaluator for %s (rev=%s)",
                  repo, (_king_revision or "?")[:12])
         return _king_evaluator
+
+    # King changed — invalidate cached baseline
+    _king_baseline = None
+    _king_baseline_key = None
 
     needs_reload = _king_evaluator is not None
     if needs_reload:
@@ -330,6 +358,97 @@ def _run_eval(eval_id: str, req: EvalRequest):
 
 
 # ---------------------------------------------------------------------------
+# Batch mode runners
+# ---------------------------------------------------------------------------
+
+def _run_king_baseline(eval_id: str, req: KingBaselineRequest):
+    global _king_baseline, _king_baseline_key
+    record = _evals[eval_id]
+    record["state"] = "running"
+    event_q: Queue = record["events"]
+
+    try:
+        king_eval = _ensure_king(req.king_repo, req.king_hash, req.king_revision)
+
+        baseline_key = f"{req.shard_key}:{req.seed_str}"
+        if _king_baseline and _king_baseline_key == baseline_key:
+            log.info("reusing cached king baseline for %s", baseline_key[:40])
+            baseline = _king_baseline
+        else:
+            def _on_progress(info):
+                record["progress"] = info
+                event_q.put({"type": "progress", "data": info})
+
+            baseline = compute_king_baseline(
+                king_eval, _r2, req.shard_key, req.eval_n,
+                req.seq_len, req.batch_size, req.seed_str,
+                on_progress=_on_progress,
+            )
+            _king_baseline = baseline
+            _king_baseline_key = baseline_key
+
+        result = {
+            "actual_N": baseline["actual_N"],
+            "avg_king_loss": baseline["avg_king_loss"],
+            "wall_time_s": baseline["wall_time_s"],
+        }
+        record["state"] = "completed"
+        record["verdict"] = result
+        event_q.put({"type": "verdict", "data": result})
+
+    except Exception as e:
+        log.exception("king baseline %s failed", eval_id)
+        record["state"] = "failed"
+        record["error"] = str(e)
+        event_q.put({"type": "error", "data": {"error": str(e)}})
+
+    finally:
+        _prune_evals()
+        _eval_lock.release()
+
+
+def _run_challenger_eval(eval_id: str, req: ChallengerEvalRequest):
+    record = _evals[eval_id]
+    record["state"] = "running"
+    event_q: Queue = record["events"]
+
+    try:
+        challenger_eval = _load_challenger(req.challenger_repo, req.challenger_revision)
+
+        def _on_progress(info):
+            record["progress"] = info
+            event_q.put({"type": "progress", "data": info})
+
+        verdict = eval_challenger_against_baseline(
+            challenger_eval, _king_baseline,
+            req.alpha, req.delta,
+            req.batch_size,
+            n_bootstrap=req.n_bootstrap,
+            on_progress=_on_progress,
+        )
+
+        challenger_eval.shutdown()
+        del challenger_eval
+        torch.cuda.empty_cache()
+
+        record["state"] = "completed"
+        record["verdict"] = verdict
+        event_q.put({"type": "verdict", "data": verdict})
+
+        _cleanup_hf_cache()
+
+    except Exception as e:
+        log.exception("challenger eval %s failed", eval_id)
+        record["state"] = "failed"
+        record["error"] = str(e)
+        event_q.put({"type": "error", "data": {"error": str(e)}})
+
+    finally:
+        _prune_evals()
+        _eval_lock.release()
+
+
+# ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
 
@@ -365,6 +484,54 @@ async def start_eval(req: EvalRequest):
     thread = threading.Thread(target=_run_eval, args=(eval_id, req), daemon=True)
     thread.start()
 
+    return {"eval_id": eval_id}
+
+
+@app.post("/eval/king-baseline")
+async def start_king_baseline(req: KingBaselineRequest):
+    acquired = _eval_lock.acquire(blocking=False)
+    if not acquired:
+        raise HTTPException(status_code=409, detail="an eval is already running")
+
+    eval_id = uuid.uuid4().hex[:8]
+    _evals[eval_id] = {
+        "state": "pending",
+        "progress": {},
+        "verdict": None,
+        "error": None,
+        "request": req.model_dump(),
+        "events": Queue(),
+        "created_at": time.time(),
+    }
+
+    thread = threading.Thread(target=_run_king_baseline, args=(eval_id, req), daemon=True)
+    thread.start()
+    return {"eval_id": eval_id}
+
+
+@app.post("/eval/challenger")
+async def start_challenger_eval(req: ChallengerEvalRequest):
+    if not _king_baseline:
+        raise HTTPException(status_code=400,
+                            detail="no king baseline computed; call /eval/king-baseline first")
+
+    acquired = _eval_lock.acquire(blocking=False)
+    if not acquired:
+        raise HTTPException(status_code=409, detail="an eval is already running")
+
+    eval_id = uuid.uuid4().hex[:8]
+    _evals[eval_id] = {
+        "state": "pending",
+        "progress": {},
+        "verdict": None,
+        "error": None,
+        "request": req.model_dump(),
+        "events": Queue(),
+        "created_at": time.time(),
+    }
+
+    thread = threading.Thread(target=_run_challenger_eval, args=(eval_id, req), daemon=True)
+    thread.start()
     return {"eval_id": eval_id}
 
 

--- a/eval_torch.py
+++ b/eval_torch.py
@@ -642,6 +642,155 @@ def run_bootstrap_test(king_eval, challenger_eval, r2, shard_key, eval_n,
 
 
 # ---------------------------------------------------------------------------
+# Batch mode — decomposed king baseline + challenger eval
+# ---------------------------------------------------------------------------
+
+def compute_king_baseline(king_eval, r2, shard_key, eval_n, seq_len, batch_size,
+                          seed_str, on_progress=None):
+    """Compute king losses on deterministic sequences. Returns reusable baseline.
+
+    The returned dict contains everything needed to evaluate multiple challengers
+    against the same data without recomputing king losses.
+    """
+    n_tokens = get_shard_info(r2, shard_key)
+    n_sequences = n_tokens // seq_len
+    actual_N = min(eval_n, n_sequences)
+    log.info("king baseline: N=%d actual_N=%d shard=%s", eval_n, actual_N, shard_key)
+
+    seed_material = seed_str.encode()
+    seed = int.from_bytes(hashlib.blake2b(seed_material, digest_size=8).digest(), "little")
+    rng = np.random.Generator(np.random.PCG64(seed))
+    eval_indices = rng.choice(n_sequences, size=actual_N, replace=False).tolist()
+
+    log.info("downloading shard %s ...", shard_key)
+    data_offset, shard_data = download_shard(r2, shard_key)
+
+    log.info("extracting %d sequences", actual_N)
+    seq_cache = extract_sequences(shard_data, data_offset, eval_indices, seq_len)
+    log.info("extracted %d sequences", len(seq_cache))
+
+    batches = [eval_indices[i:i + batch_size] for i in range(0, len(eval_indices), batch_size)]
+
+    king_losses_all = []
+    t0 = time.time()
+    total_done = 0
+
+    for bi, batch_indices in enumerate(batches):
+        token_batches = [seq_cache[idx] for idx in batch_indices]
+        king_losses = king_eval.compute_losses(token_batches)
+        king_losses_all.extend(king_losses)
+        total_done += len(batch_indices)
+
+        elapsed = time.time() - t0
+        log.info("king baseline batch %d/%d | done=%d/%d | %.1f seq/s",
+                 bi + 1, len(batches), total_done, actual_N,
+                 total_done / elapsed if elapsed > 0 else 0)
+
+        if on_progress:
+            on_progress({
+                "done": total_done, "total": actual_N,
+                "phase": "king_baseline",
+                "avg_king_loss": round(sum(king_losses_all) / total_done, 6),
+                "seqs_per_sec": round(total_done / elapsed, 1) if elapsed > 0 else 0,
+            })
+
+    elapsed = time.time() - t0
+    avg_king_loss = round(sum(king_losses_all) / len(king_losses_all), 6)
+    log.info("king baseline complete: avg_loss=%.6f N=%d %.1fs", avg_king_loss, actual_N, elapsed)
+
+    return {
+        "eval_indices": eval_indices,
+        "seq_cache": seq_cache,
+        "king_losses": king_losses_all,
+        "seed": seed,
+        "actual_N": actual_N,
+        "shard_key": shard_key,
+        "wall_time_s": round(elapsed, 1),
+        "avg_king_loss": avg_king_loss,
+    }
+
+
+def eval_challenger_against_baseline(challenger_eval, baseline, alpha, delta,
+                                     batch_size, n_bootstrap=10000,
+                                     on_progress=None):
+    """Evaluate a challenger against pre-computed king baseline.
+
+    Uses the same sequences and king losses from the baseline dict.
+    Returns a verdict dict identical in structure to run_bootstrap_test output.
+    """
+    eval_indices = baseline["eval_indices"]
+    seq_cache = baseline["seq_cache"]
+    king_losses_all = baseline["king_losses"]
+    seed = baseline["seed"]
+    actual_N = baseline["actual_N"]
+
+    batches = [eval_indices[i:i + batch_size] for i in range(0, len(eval_indices), batch_size)]
+
+    chall_losses_all = []
+    t0 = time.time()
+    total_done = 0
+
+    for bi, batch_indices in enumerate(batches):
+        token_batches = [seq_cache[idx] for idx in batch_indices]
+        chall_losses = challenger_eval.compute_losses(token_batches)
+        chall_losses_all.extend(chall_losses)
+        total_done += len(batch_indices)
+
+        elapsed = time.time() - t0
+        king_sum = sum(king_losses_all[:total_done])
+        chall_sum = sum(chall_losses_all)
+        diffs_so_far = [k - c for k, c in zip(king_losses_all[:total_done], chall_losses_all)]
+        mu_hat = float(np.mean(diffs_so_far)) if diffs_so_far else 0.0
+
+        log.info("challenger batch %d/%d | done=%d/%d | mu_hat=%.6f | %.1f seq/s",
+                 bi + 1, len(batches), total_done, actual_N, mu_hat,
+                 total_done / elapsed if elapsed > 0 else 0)
+
+        if on_progress:
+            on_progress({
+                "done": total_done, "total": actual_N,
+                "mu_hat": round(mu_hat, 6),
+                "avg_king_loss": round(king_sum / total_done, 6),
+                "avg_challenger_loss": round(chall_sum / total_done, 6),
+                "seqs_per_sec": round(total_done / elapsed, 1) if elapsed > 0 else 0,
+            })
+
+    elapsed = time.time() - t0
+    all_diffs = [k - c for k, c in zip(king_losses_all, chall_losses_all)]
+    d = np.array(all_diffs)
+    mu_hat = float(d.mean())
+
+    boot_rng = np.random.Generator(np.random.PCG64(seed ^ 0xB007))
+    boot_means = np.empty(n_bootstrap)
+    for b in range(n_bootstrap):
+        idx = boot_rng.integers(0, len(d), size=len(d))
+        boot_means[b] = d[idx].mean()
+    lcb = float(np.quantile(boot_means, alpha))
+
+    accepted = lcb > delta
+    king_sum = sum(king_losses_all)
+    chall_sum = sum(chall_losses_all)
+    log.info("challenger result: mu_hat=%.6f lcb=%.6f delta=%.6f accepted=%s",
+             mu_hat, lcb, delta, accepted)
+
+    return {
+        "accepted": accepted,
+        "verdict": "challenger" if accepted else "king",
+        "mu_hat": round(mu_hat, 6),
+        "lcb": round(lcb, 6),
+        "delta": delta,
+        "alpha": alpha,
+        "n_bootstrap": n_bootstrap,
+        "N": actual_N,
+        "avg_king_loss": round(king_sum / actual_N, 6) if actual_N else 0,
+        "avg_challenger_loss": round(chall_sum / actual_N, 6) if actual_N else 0,
+        "wall_time_s": round(elapsed, 1),
+        "seqs_per_sec": round(actual_N / elapsed, 1) if elapsed > 0 else 0,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 

--- a/validator.py
+++ b/validator.py
@@ -59,6 +59,8 @@ TMC_API_KEY = os.environ.get("TMC_API_KEY", "")
 DISCORD_BOT_TOKEN = os.environ.get("DISCORD_BOT_TOKEN", "")
 DISCORD_CHANNEL_ID = os.environ.get("DISCORD_CHANNEL_ID", "")
 
+BATCH_MAX = int(os.environ.get("TEUTONIC_BATCH_MAX", "5"))
+
 REPO_PATTERN = r"^[^/]+/Teutonic-I-.+$"
 
 TMC_BASE = "https://api.taomarketcap.com/public/v1"
@@ -805,6 +807,263 @@ async def process_challenge(state, r2, entry, subtensor, wallet, *, check_stale=
     state.flush()
 
 
+async def process_batch(state, r2, batch_entries, subtensor, wallet):
+    """Evaluate a batch of challengers against shared king baseline, crown the best."""
+
+    # --- Phase 0: Validate and prepare entries ---
+    valid_entries = []
+    for entry in batch_entries:
+        cid = entry["challenge_id"]
+        hotkey = entry["hotkey"]
+        hf_repo = entry["hf_repo"]
+
+        king_hotkey = state.king.get("hotkey", "")
+        if king_hotkey and hotkey == king_hotkey:
+            log.info("batch: skipping %s: hotkey is current king", cid)
+            continue
+        if hf_repo in state.failed_repos:
+            log.info("batch: skipping %s: repo %s previously failed", cid, hf_repo)
+            continue
+        if hf_repo in state.evaluated_repos:
+            log.info("batch: skipping %s: repo %s already evaluated", cid, hf_repo)
+            continue
+
+        rejection = validate_challenger_config(
+            hf_repo,
+            king_repo=state.king.get("hf_repo", ""),
+            king_revision=state.king.get("king_revision", ""),
+        )
+        if rejection:
+            log.warning("batch: rejecting %s (%s): %s", cid, hf_repo, rejection)
+            state.failed_repos.add(hf_repo)
+            state.event({"event": "config_rejected", "challenge_id": cid,
+                         "hf_repo": hf_repo, "reason": rejection})
+            continue
+
+        try:
+            info = HfApi(token=HF_TOKEN or None).model_info(hf_repo, revision="main")
+            entry["challenger_revision"] = info.sha
+            log.info("batch: %s pinned at %s", hf_repo, info.sha[:12])
+        except Exception:
+            log.warning("batch: cannot get SHA for %s, skipping", hf_repo)
+            state.failed_repos.add(hf_repo)
+            continue
+
+        valid_entries.append(entry)
+
+    if not valid_entries:
+        log.info("batch: no valid entries after validation")
+        return
+
+    log.info("batch: %d valid challengers", len(valid_entries))
+
+    # --- Phase 1: Compute batch-level shard + seed ---
+    ref_block = valid_entries[0]["block"]
+    block_hash = "default"
+    try:
+        block_hash = subtensor.get_block_hash(ref_block) or "default"
+    except Exception:
+        pass
+
+    king_hash = state.king.get("king_hash", "")
+    seed_str = f"{block_hash}:{king_hash}"
+
+    manifest = r2.get("dataset/v1/manifest.json")
+    if not manifest:
+        log.error("batch: no dataset manifest")
+        return
+    n_shards = manifest["total_shards"]
+    shard_idx = int.from_bytes(
+        hashlib.blake2b(seed_str.encode(), digest_size=8).digest(), "little"
+    ) % n_shards
+    shard_key = manifest["shards"][shard_idx]["key"]
+
+    king_repo = state.king.get("hf_repo", SEED_REPO)
+    king_revision = state.king.get("king_revision", "")
+
+    # --- Phase 2: Compute king baseline ---
+    log.info("batch: computing king baseline on shard %s", shard_key)
+    state.current_eval = {
+        "challenge_id": "batch-king-baseline",
+        "challenger_repo": "(king baseline)",
+        "hotkey": "",
+        "progress": 0, "total": EVAL_N, "mu_hat": 0,
+        "avg_king_loss": 0, "avg_challenger_loss": 0,
+        "loading": True,
+        "started_at": _now(),
+        "batch_total": len(valid_entries),
+    }
+    state.flush_dashboard()
+
+    async with httpx.AsyncClient(timeout=httpx.Timeout(1800.0, connect=30.0)) as client:
+        resp = await client.post(f"{EVAL_SERVER_URL}/eval/king-baseline", json={
+            "king_repo": king_repo,
+            "shard_key": shard_key,
+            "seed_str": seed_str,
+            "king_hash": king_hash,
+            "king_revision": king_revision,
+            "eval_n": EVAL_N,
+            "seq_len": SEQ_LEN,
+        })
+        resp.raise_for_status()
+        eval_id = resp.json()["eval_id"]
+        log.info("batch: king baseline dispatched as %s", eval_id)
+
+        async with client.stream("GET", f"{EVAL_SERVER_URL}/eval/{eval_id}/stream",
+                                  timeout=httpx.Timeout(1800.0)) as stream:
+            async for line in stream.aiter_lines():
+                if not line.startswith("data: "):
+                    continue
+                event = json.loads(line[6:])
+                if event["type"] == "progress":
+                    d = event["data"]
+                    state.current_eval.update({
+                        "progress": d.get("done", 0),
+                        "total": d.get("total", EVAL_N),
+                        "avg_king_loss": d.get("avg_king_loss", 0),
+                    })
+                    state.flush_dashboard()
+                elif event["type"] == "verdict":
+                    baseline_result = event["data"]
+                    log.info("batch: king baseline complete: avg_king_loss=%.6f (%.1fs)",
+                             baseline_result["avg_king_loss"], baseline_result["wall_time_s"])
+                    break
+                elif event["type"] == "error":
+                    raise RuntimeError(f"king baseline error: {event['data']}")
+
+    # --- Phase 3: Evaluate each challenger ---
+    verdicts = []
+
+    for i, entry in enumerate(valid_entries):
+        cid = entry["challenge_id"]
+        hotkey = entry["hotkey"]
+        hf_repo = entry["hf_repo"]
+        challenger_revision = entry["challenger_revision"]
+
+        log.info("batch: evaluating challenger %d/%d: %s (%s)",
+                 i + 1, len(valid_entries), cid, hf_repo)
+
+        r2.put(f"eval/{cid}/meta.json", {
+            "challenge_id": cid, "king_repo": king_repo,
+            "king_revision": king_revision,
+            "challenger_repo": hf_repo, "challenger_revision": challenger_revision,
+            "hotkey": hotkey, "batch_mode": True,
+            "N": EVAL_N, "alpha": EVAL_ALPHA, "delta": EVAL_DELTA, "shard": shard_key,
+        })
+
+        state.current_eval = {
+            "challenge_id": cid, "challenger_repo": hf_repo, "hotkey": hotkey,
+            "progress": 0, "total": EVAL_N, "mu_hat": 0,
+            "avg_king_loss": 0, "avg_challenger_loss": 0,
+            "started_at": _now(),
+            "batch_index": i + 1,
+            "batch_total": len(valid_entries),
+        }
+        state.flush_dashboard()
+
+        verdict = None
+        try:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(1800.0, connect=30.0)) as client:
+                resp = await client.post(f"{EVAL_SERVER_URL}/eval/challenger", json={
+                    "challenger_repo": hf_repo,
+                    "challenger_revision": challenger_revision,
+                    "alpha": EVAL_ALPHA,
+                    "delta": EVAL_DELTA,
+                })
+                resp.raise_for_status()
+                eval_id = resp.json()["eval_id"]
+
+                async with client.stream("GET", f"{EVAL_SERVER_URL}/eval/{eval_id}/stream",
+                                          timeout=httpx.Timeout(1800.0)) as stream:
+                    async for line in stream.aiter_lines():
+                        if not line.startswith("data: "):
+                            continue
+                        event = json.loads(line[6:])
+                        if event["type"] == "progress":
+                            d = event["data"]
+                            state.current_eval.update({
+                                "progress": d.get("done", 0),
+                                "total": d.get("total", EVAL_N),
+                                "mu_hat": d.get("mu_hat", 0),
+                                "avg_king_loss": d.get("avg_king_loss", 0),
+                                "avg_challenger_loss": d.get("avg_challenger_loss", 0),
+                            })
+                            state.flush_dashboard()
+                        elif event["type"] == "verdict":
+                            verdict = event["data"]
+                            verdict["challenge_id"] = cid
+                            break
+                        elif event["type"] == "error":
+                            raise RuntimeError(f"eval server error: {event['data']}")
+
+        except Exception:
+            log.exception("batch: eval failed for %s", cid)
+            state.stats["failed"] += 1
+            state.current_eval = None
+            state.flush_dashboard()
+            continue
+
+        if not verdict:
+            log.error("batch: no verdict for %s", cid)
+            state.stats["failed"] += 1
+            continue
+
+        r2.put(f"eval/{cid}/verdict.json", verdict)
+        log.info("batch: %s verdict: %s (mu_hat=%.6f lcb=%.6f)",
+                 cid, verdict["verdict"], verdict.get("mu_hat", 0), verdict.get("lcb", 0))
+
+        state.evaluated_repos.add(hf_repo)
+        state.record_verdict(verdict, hf_repo, hotkey)
+
+        if verdict.get("accepted", False):
+            state.stats["accepted"] += 1
+            verdicts.append((entry, verdict))
+        else:
+            state.stats["rejected"] += 1
+
+        state.event({"event": "eval_completed", "challenge_id": cid,
+                     "hotkey": hotkey, "accepted": verdict.get("accepted", False),
+                     **verdict})
+
+    # --- Phase 4: Select best ---
+    state.current_eval = None
+
+    if not verdicts:
+        log.info("batch: no challengers accepted (%d evaluated)", len(valid_entries))
+        state.flush_dashboard()
+        state.flush()
+        return
+
+    best_entry, best_verdict = max(verdicts, key=lambda x: x[1].get("mu_hat", 0))
+    best_cid = best_entry["challenge_id"]
+    best_hotkey = best_entry["hotkey"]
+    best_repo = best_entry["hf_repo"]
+    best_revision = best_entry["challenger_revision"]
+
+    log.info("BATCH WINNER: %s from %s (mu_hat=%.6f, %d/%d accepted)",
+             best_cid, best_hotkey[:16], best_verdict.get("mu_hat", 0),
+             len(verdicts), len(valid_entries))
+
+    state.set_king(best_hotkey, best_repo, best_entry.get("model_hash", ""),
+                   best_entry.get("block", 0), best_cid,
+                   king_revision=best_revision)
+    state.last_winner_hotkey = best_hotkey
+    await notify_new_king(state.king, best_verdict)
+    if set_weights(subtensor, wallet, NETUID, best_hotkey):
+        state.last_weight_block = subtensor.block
+
+    state.flush()
+    state.flush_dashboard()
+    state.event({
+        "event": "batch_completed",
+        "batch_size": len(valid_entries),
+        "accepted_count": len(verdicts),
+        "winner_challenge_id": best_cid,
+        "winner_hotkey": best_hotkey,
+        "winner_mu_hat": best_verdict.get("mu_hat", 0),
+    })
+
+
 async def main():
     args = parse_args()
 
@@ -863,10 +1122,10 @@ async def main():
     signal.signal(signal.SIGTERM, _on_signal)
     signal.signal(signal.SIGINT, _on_signal)
 
-    log.info("validator running | king=%s@%s | eval_server=%s | poll=%ds",
+    log.info("validator running | king=%s@%s | eval_server=%s | poll=%ds | batch_max=%d",
              state.king.get("hf_repo", "?"),
              state.king.get("king_revision", "?")[:12],
-             EVAL_SERVER_URL, POLL_INTERVAL)
+             EVAL_SERVER_URL, POLL_INTERVAL, BATCH_MAX)
 
     while True:
         try:
@@ -889,39 +1148,75 @@ async def main():
                     if cid:
                         log.info("queued %s from %s (new)", cid, rev["hotkey"][:16])
 
-            while state.queue:
-                entry = state.queue.pop(0)
-                is_reeval = entry.get("reeval", False)
-                state.current_eval = {
-                    "challenge_id": entry.get("challenge_id", "?"),
-                    "challenger_repo": entry.get("hf_repo", ""),
-                    "hotkey": entry.get("hotkey", ""),
-                    "progress": 0, "total": EVAL_N, "mu_hat": 0,
-                    "avg_king_loss": 0, "avg_challenger_loss": 0,
-                    "loading": True,
-                    "started_at": _now(),
-                }
-                state.flush_dashboard()
-                state.flush()
-                try:
-                    await process_challenge(state, r2, entry, subtensor, wallet,
-                                            check_stale=not is_reeval and args.seen)
-                except Exception:
-                    log.exception("eval failed: %s", entry.get("challenge_id"))
-                    state.stats["failed"] += 1
-                    state.current_eval = None
+            if BATCH_MAX <= 1:
+                # Legacy single-eval mode (unchanged)
+                while state.queue:
+                    entry = state.queue.pop(0)
+                    is_reeval = entry.get("reeval", False)
+                    state.current_eval = {
+                        "challenge_id": entry.get("challenge_id", "?"),
+                        "challenger_repo": entry.get("hf_repo", ""),
+                        "hotkey": entry.get("hotkey", ""),
+                        "progress": 0, "total": EVAL_N, "mu_hat": 0,
+                        "avg_king_loss": 0, "avg_challenger_loss": 0,
+                        "loading": True,
+                        "started_at": _now(),
+                    }
                     state.flush_dashboard()
-
-                fresh = scan_reveals(subtensor, NETUID, state.seen)
-                if fresh:
                     state.flush()
-                    for rev in fresh:
-                        cid = state.enqueue(rev)
-                        if cid:
-                            log.info("queued %s from %s (new, mid-cycle)", cid, rev["hotkey"][:16])
+                    try:
+                        await process_challenge(state, r2, entry, subtensor, wallet,
+                                                check_stale=not is_reeval and args.seen)
+                    except Exception:
+                        log.exception("eval failed: %s", entry.get("challenge_id"))
+                        state.stats["failed"] += 1
+                        state.current_eval = None
+                        state.flush_dashboard()
+
+                    fresh = scan_reveals(subtensor, NETUID, state.seen)
+                    if fresh:
+                        state.flush()
+                        for rev in fresh:
+                            cid = state.enqueue(rev)
+                            if cid:
+                                log.info("queued %s from %s (new, mid-cycle)", cid, rev["hotkey"][:16])
+                        new_items = [e for e in state.queue if not e.get("reeval")]
+                        reeval_items = [e for e in state.queue if e.get("reeval")]
+                        state.queue = new_items + reeval_items
+            else:
+                # Batch mode: evaluate all pending, crown the best
+                while state.queue:
                     new_items = [e for e in state.queue if not e.get("reeval")]
                     reeval_items = [e for e in state.queue if e.get("reeval")]
-                    state.queue = new_items + reeval_items
+                    batch = new_items[:BATCH_MAX]
+                    remaining_slots = BATCH_MAX - len(batch)
+                    if remaining_slots > 0:
+                        batch.extend(reeval_items[:remaining_slots])
+
+                    batch_ids = {e["challenge_id"] for e in batch}
+                    state.queue = [e for e in state.queue if e["challenge_id"] not in batch_ids]
+
+                    log.info("batch: collected %d challengers (max=%d, queue_remaining=%d)",
+                             len(batch), BATCH_MAX, len(state.queue))
+
+                    try:
+                        await process_batch(state, r2, batch, subtensor, wallet)
+                    except Exception:
+                        log.exception("batch eval failed")
+                        state.stats["failed"] += len(batch)
+                        state.current_eval = None
+                        state.flush_dashboard()
+
+                    fresh = scan_reveals(subtensor, NETUID, state.seen)
+                    if fresh:
+                        state.flush()
+                        for rev in fresh:
+                            cid = state.enqueue(rev)
+                            if cid:
+                                log.info("queued %s from %s (new, mid-cycle)", cid, rev["hotkey"][:16])
+                        new_items = [e for e in state.queue if not e.get("reeval")]
+                        reeval_items = [e for e in state.queue if e.get("reeval")]
+                        state.queue = new_items + reeval_items
 
             state.current_eval = None
 


### PR DESCRIPTION
## Background

The current validator crowns the first challenger that passes the bootstrap threshold (LCB > delta). This rewards submission speed rather than model quality — miners race to submit first instead of training better models.

## What this PR does

Adds a batch evaluation mode: instead of accepting the first passing challenger, the validator collects pending submissions into a batch, evaluates all of them on the **same shard and sequences**, then selects the one with the highest μ̂.

Key design choices:

- **Shared king baseline**: King losses are computed once per batch and reused across all challengers. This cuts ~50% of GPU time per additional challenger.
- **Same evaluation data**: All challengers in a batch are compared on identical sequences, eliminating data-induced variance from the comparison.
- **Backward compatible**: Controlled by `TEUTONIC_BATCH_MAX` env var (default 5). Set to 1 to restore the original first-to-pass behavior.

## Changes

- `eval_torch.py`: Two new functions (`compute_king_baseline`, `eval_challenger_against_baseline`) that decompose `run_bootstrap_test` into reusable phases. Original function untouched.
- `eval_server.py`: Two new endpoints (`POST /eval/king-baseline`, `POST /eval/challenger`). Original `POST /eval` untouched.
- `validator.py`: New `process_batch()` function and main loop branching on `BATCH_MAX`.