### PR TITLE
Remove HF download path, add model cache cleanup and PM2 configs

### DIFF
--- a/ecosystem.cleanup.config.js
+++ b/ecosystem.cleanup.config.js
@@ -1,0 +1,33 @@
+// PM2 config for the model cache cleanup job.
+// Runs cleanup_model_cache.py every 30 minutes via cron_restart.
+// autorestart: false ensures PM2 does not restart the script immediately
+// after it exits — it waits for the next cron tick instead.
+//
+// Start:  pm2 start ecosystem.cleanup.config.js
+// Reload: pm2 reload ecosystem.cleanup.config.js
+
+module.exports = {
+  apps: [{
+    name: "teutonic-king-ref",
+    script: "scripts/write_king_ref.py",
+    interpreter: "/root/teutonic/.venv/bin/python",
+    cwd: "/root/teutonic",
+    cron_restart: "*/5 * * * *",
+    autorestart: false,
+    log_date_format: "YYYY-MM-DD HH:mm:ss",
+    env: {
+      PYTHONUNBUFFERED: "1",
+    },
+  }, {
+    name: "teutonic-model-cache-cleanup",
+    script: "scripts/cleanup_model_cache.py",
+    interpreter: "/root/teutonic/.venv/bin/python",
+    cwd: "/root/teutonic",
+    cron_restart: "*/30 * * * *",
+    autorestart: false,
+    log_date_format: "YYYY-MM-DD HH:mm:ss",
+    env: {
+      PYTHONUNBUFFERED: "1",
+    },
+  }],
+};

--- a/ecosystem.eval.config.js
+++ b/ecosystem.eval.config.js
@@ -1,0 +1,22 @@
+// PM2 entry for the eval server host.
+//
+// Keeps eval-server supervision separate from the validator/tunnel config in
+// ecosystem.config.js. The launcher script owns env loading and uvicorn args.
+
+module.exports = {
+  apps: [{
+    name: "teutonic-eval-quasar",
+    script: "/root/start_eval_quasar.sh",
+    interpreter: "/bin/bash",
+    cwd: "/root",
+    exec_mode: "fork",
+    autorestart: true,
+    restart_delay: 5000,
+    max_restarts: 1000,
+    kill_timeout: 10000,
+    log_date_format: "YYYY-MM-DD HH:mm:ss",
+    env: {
+      PYTHONUNBUFFERED: "1",
+    },
+  }],
+};

--- a/scripts/cleanup_model_cache.py
+++ b/scripts/cleanup_model_cache.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Standalone cleanup script for the Teutonic Quasar pair-eval model cache.
+
+Removes:
+  - Incomplete (partial) snapshot dirs left by failed/crashed downloads
+  - Snapshot dirs older than --max-age-days that are not actively in use
+  - Excess snapshots beyond --keep-recent per model when total cache exceeds --watermark-gb
+
+Safety:
+  - Directories newer than --min-age-hours are never touched (grace window)
+  - Open file descriptors (/proc/*/fd) and memory-mapped files (/proc/*/maps) are
+    detected, so any snapshot currently loaded by the eval server is skipped
+  - --dry-run shows what would be deleted without removing anything
+
+Usage:
+    python cleanup_model_cache.py --dry-run
+    python cleanup_model_cache.py
+    python cleanup_model_cache.py --min-age-hours 2 --max-age-days 3 --keep-recent 2
+    python cleanup_model_cache.py --watermark-gb 200 --keep-recent 1
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import shutil
+import sys
+import time
+from pathlib import Path
+
+log = logging.getLogger("cleanup_model_cache")
+
+DEFAULT_CACHE_DIR = Path(os.environ.get("TEUTONIC_MODEL_CACHE_DIR", "/tmp/teutonic/quasar_pair_models"))
+DEFAULT_MIN_AGE_H = float(os.environ.get("MODEL_CACHE_MIN_AGE_H", "1"))
+DEFAULT_MAX_AGE_DAYS = float(os.environ.get("MODEL_CACHE_MAX_AGE_DAYS", str(3 / 24)))
+DEFAULT_KEEP_RECENT = int(os.environ.get("MODEL_CACHE_KEEP_RECENT", "1"))
+DEFAULT_WATERMARK_GB = float(os.environ.get("MODEL_CACHE_HIGH_WATERMARK_GB", "500"))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def setup_logging(verbose: bool = False) -> None:
+    logging.basicConfig(
+        level=logging.DEBUG if verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s  %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+
+def dir_size_bytes(path: Path) -> int:
+    try:
+        return sum(f.stat().st_size for f in path.rglob("*") if f.is_file())
+    except Exception:
+        return 0
+
+
+def snapshot_is_complete(path: Path) -> bool:
+    """True if the directory looks like a complete model snapshot."""
+    if not (path / "config.json").exists():
+        return False
+    return any(path.glob("*.safetensors"))
+
+
+def find_snapshot_dirs(cache_dir: Path) -> list[Path]:
+    """Return all snapshot dirs (two levels deep: <model-slug>/<digest>)."""
+    dirs: list[Path] = []
+    try:
+        for model_dir in cache_dir.iterdir():
+            if not model_dir.is_dir():
+                continue
+            for snap_dir in model_dir.iterdir():
+                if snap_dir.is_dir():
+                    dirs.append(snap_dir)
+    except OSError:
+        pass
+    return dirs
+
+
+def _register_path_under_cache(path_str: str, cache_dir: Path, active: set[str]) -> None:
+    """If path_str is inside cache_dir, add its snapshot-level parent to active."""
+    cache_str = str(cache_dir.resolve())
+    if not path_str.startswith(cache_str):
+        return
+    try:
+        rel = Path(path_str).relative_to(cache_dir)
+        parts = rel.parts
+        if len(parts) >= 2:
+            snap = cache_dir / parts[0] / parts[1]
+            active.add(str(snap.resolve()))
+    except ValueError:
+        pass
+
+
+def detect_active_snapshot_dirs(cache_dir: Path) -> set[str]:
+    """
+    Return resolved paths of snapshot dirs currently in use by any process.
+
+    Checks:
+    - /proc/*/fd    — open file descriptors (config.json, tokenizer files, etc.)
+    - /proc/*/maps  — memory-mapped regions (safetensors weights loaded with mmap)
+    """
+    cache_dir = cache_dir.resolve()
+    active: set[str] = set()
+
+    # Open file descriptors
+    for fd_dir in Path("/proc").glob("*/fd"):
+        try:
+            for fd_link in fd_dir.iterdir():
+                try:
+                    target = os.readlink(fd_link)
+                    _register_path_under_cache(target, cache_dir, active)
+                except OSError:
+                    pass
+        except (OSError, PermissionError):
+            pass
+
+    # Memory-mapped files (safetensors are loaded with mmap by default)
+    for maps_file in Path("/proc").glob("*/maps"):
+        try:
+            with open(maps_file) as f:
+                for line in f:
+                    # format: addr perms offset dev inode /path
+                    parts = line.split()
+                    if len(parts) >= 6:
+                        _register_path_under_cache(parts[5], cache_dir, active)
+        except (OSError, PermissionError):
+            pass
+
+    return active
+
+
+def read_king_ref(cache_dir: Path) -> str | None:
+    """Read the snapshot path of the currently loaded king model written by the eval server."""
+    try:
+        path = (cache_dir / ".current_king").read_text().strip()
+        return path or None
+    except OSError:
+        return None
+
+
+def fmt_gb(b: int | float) -> str:
+    return f"{b / 1e9:.2f} GB"
+
+
+def fmt_age(age_s: float) -> str:
+    if age_s < 3600:
+        return f"{age_s / 60:.0f}m"
+    if age_s < 86400:
+        return f"{age_s / 3600:.1f}h"
+    return f"{age_s / 86400:.1f}d"
+
+
+# ---------------------------------------------------------------------------
+# Main cleanup logic
+# ---------------------------------------------------------------------------
+
+def run_cleanup(
+    cache_dir: Path,
+    min_age_s: float,
+    max_age_s: float,
+    keep_recent: int,
+    watermark_bytes: float,
+    dry_run: bool,
+) -> dict:
+    if not cache_dir.exists():
+        log.info("cache dir does not exist: %s — nothing to do", cache_dir)
+        return {"deleted": 0, "freed_bytes": 0}
+
+    now = time.time()
+
+    # -----------------------------------------------------------------------
+    # Detect dirs currently in use by the eval server process
+    # -----------------------------------------------------------------------
+    log.info("scanning /proc for open/mmap'd files under %s …", cache_dir)
+    active_dirs = detect_active_snapshot_dirs(cache_dir)
+
+    king_ref = read_king_ref(cache_dir)
+    if king_ref:
+        king_resolved = str(Path(king_ref).resolve())
+        active_dirs.add(king_resolved)
+        log.info("current king (from .current_king): %s", king_ref)
+    else:
+        log.info("no .current_king ref found (eval server not running or king not yet loaded)")
+
+    if active_dirs:
+        log.info("%d snapshot dir(s) protected (in-use or current king):", len(active_dirs))
+        for d in sorted(active_dirs):
+            log.info("  protected: %s", d)
+    else:
+        log.info("no protected snapshot dirs detected")
+
+    snapshots = find_snapshot_dirs(cache_dir)
+    if not snapshots:
+        log.info("no snapshot dirs found under %s", cache_dir)
+        return {"deleted": 0, "freed_bytes": 0}
+
+    log.info("%d snapshot dir(s) found", len(snapshots))
+
+    # Helpers
+    def snap_age(d: Path) -> float:
+        try:
+            return now - d.stat().st_mtime
+        except Exception:
+            return 0.0
+
+    def is_protected(d: Path) -> bool:
+        return str(d.resolve()) in active_dirs
+
+    def is_too_young(d: Path) -> bool:
+        return snap_age(d) < min_age_s
+
+    deleted_count = 0
+    freed_bytes = 0
+    remaining: list[Path] = list(snapshots)
+
+    def delete(d: Path, reason: str) -> None:
+        nonlocal deleted_count, freed_bytes
+        size = dir_size_bytes(d)
+        freed_bytes += size
+        deleted_count += 1
+        verb = "[DRY RUN] would delete" if dry_run else "deleting"
+        log.info("%s  %s", verb, d)
+        log.info("         reason: %s  |  size: %s  |  age: %s", reason, fmt_gb(size), fmt_age(snap_age(d)))
+        if not dry_run:
+            shutil.rmtree(d, ignore_errors=True)
+
+    # -----------------------------------------------------------------------
+    # Phase 1 — incomplete snapshots (partial / crashed downloads)
+    # -----------------------------------------------------------------------
+    log.info("─── phase 1: incomplete snapshots ───")
+    n_before = deleted_count
+    for d in list(remaining):
+        if is_protected(d):
+            log.debug("skip (in-use): %s", d)
+            continue
+        if is_too_young(d):
+            log.debug("skip (too young, age %s < min %s): %s", fmt_age(snap_age(d)), fmt_age(min_age_s), d)
+            continue
+        if not snapshot_is_complete(d):
+            delete(d, "incomplete snapshot (missing config.json or .safetensors)")
+            remaining.remove(d)
+    if deleted_count == n_before:
+        log.info("no incomplete snapshots found")
+
+    # -----------------------------------------------------------------------
+    # Phase 2 — expired snapshots (older than max_age_s)
+    # -----------------------------------------------------------------------
+    log.info("─── phase 2: expired snapshots (age > %s) ───", fmt_age(max_age_s))
+    n_before = deleted_count
+    for d in list(remaining):
+        if is_protected(d) or is_too_young(d):
+            continue
+        if snap_age(d) > max_age_s:
+            delete(d, f"expired (age {fmt_age(snap_age(d))} > max-age {fmt_age(max_age_s)})")
+            remaining.remove(d)
+    if deleted_count == n_before:
+        log.info("no expired snapshots found")
+
+    # -----------------------------------------------------------------------
+    # Phase 3 — keep only N most recent snapshots per model
+    # -----------------------------------------------------------------------
+    log.info("─── phase 3: keep %d most-recent snapshot(s) per model ───", keep_recent)
+    n_before = deleted_count
+    by_model: dict[str, list[Path]] = {}
+    for d in remaining:
+        if is_protected(d) or is_too_young(d):
+            continue
+        by_model.setdefault(d.parent.name, []).append(d)
+
+    for model_slug, dirs in by_model.items():
+        if len(dirs) <= keep_recent:
+            continue
+        # Sort youngest-first; keep the first keep_recent, evict the rest.
+        sorted_dirs = sorted(dirs, key=snap_age)  # ascending age = youngest first
+        to_evict = sorted_dirs[keep_recent:]
+        for d in to_evict:
+            delete(d, f"excess snapshot (keeping {keep_recent} most-recent for {model_slug})")
+            remaining.remove(d)
+
+    if deleted_count == n_before:
+        log.info("no excess snapshots found")
+
+    # -----------------------------------------------------------------------
+    # Phase 4 — LRU eviction above watermark
+    # -----------------------------------------------------------------------
+    total_bytes = sum(dir_size_bytes(d) for d in remaining)
+    log.info(
+        "─── phase 4: watermark check (cache: %s  |  limit: %s) ───",
+        fmt_gb(total_bytes),
+        fmt_gb(watermark_bytes),
+    )
+    if total_bytes > watermark_bytes:
+        target_bytes = watermark_bytes * 0.7
+        running = float(total_bytes)
+        candidates: list[tuple[float, Path, int]] = []
+        for d in remaining:
+            if is_protected(d) or is_too_young(d):
+                continue
+            try:
+                candidates.append((snap_age(d), d, dir_size_bytes(d)))
+            except Exception:
+                pass
+        candidates.sort(key=lambda x: -x[0])  # oldest first
+        for _age, d, size in candidates:
+            if running <= target_bytes:
+                break
+            delete(d, f"LRU eviction (cache {fmt_gb(int(running))} > watermark {fmt_gb(watermark_bytes)})")
+            remaining.remove(d)
+            running -= size
+        log.info("estimated cache after eviction: %s", fmt_gb(int(running)))
+    else:
+        log.info("cache is within watermark — no LRU eviction needed")
+
+    # -----------------------------------------------------------------------
+    # Summary
+    # -----------------------------------------------------------------------
+    remaining_bytes = sum(dir_size_bytes(d) for d in remaining)
+    label = "preview" if dry_run else "done"
+    log.info(
+        "═══ cleanup %s: %d snapshot(s) %s, %s freed, %s remaining ═══",
+        label,
+        deleted_count,
+        "would be deleted" if dry_run else "deleted",
+        fmt_gb(freed_bytes),
+        fmt_gb(remaining_bytes),
+    )
+
+    return {"deleted": deleted_count, "freed_bytes": freed_bytes, "remaining_bytes": remaining_bytes}
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Clean up obsolete Teutonic Quasar pair-eval model cache directories.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        default=DEFAULT_CACHE_DIR,
+        metavar="DIR",
+        help="Model cache directory to clean",
+    )
+    parser.add_argument(
+        "--min-age-hours",
+        type=float,
+        default=DEFAULT_MIN_AGE_H,
+        metavar="N",
+        help="Never delete anything newer than N hours (safety grace window)",
+    )
+    parser.add_argument(
+        "--max-age-days",
+        type=float,
+        default=DEFAULT_MAX_AGE_DAYS,
+        metavar="N",
+        help="Unconditionally delete complete snapshots older than N days",
+    )
+    parser.add_argument(
+        "--keep-recent",
+        type=int,
+        default=DEFAULT_KEEP_RECENT,
+        metavar="N",
+        help="Keep at most N most-recent snapshots per model; evict the rest",
+    )
+    parser.add_argument(
+        "--watermark-gb",
+        type=float,
+        default=DEFAULT_WATERMARK_GB,
+        metavar="N",
+        help="Also run LRU eviction when total cache size exceeds N GB",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be deleted without actually deleting anything",
+    )
+    parser.add_argument(
+        "--verbose", "-v",
+        action="store_true",
+        help="Enable DEBUG-level logging (shows skipped dirs)",
+    )
+    args = parser.parse_args()
+
+    setup_logging(args.verbose)
+
+    if args.dry_run:
+        log.info("DRY RUN — no files will be deleted")
+
+    result = run_cleanup(
+        cache_dir=args.cache_dir.resolve(),
+        min_age_s=args.min_age_hours * 3600,
+        max_age_s=args.max_age_days * 86400,
+        keep_recent=args.keep_recent,
+        watermark_bytes=args.watermark_gb * 1e9,
+        dry_run=args.dry_run,
+    )
+
+    sys.exit(0 if result["deleted"] >= 0 else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/experiments/divide_safetensors.py
+++ b/scripts/experiments/divide_safetensors.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Split a single model.safetensors into Transformers-compatible shards."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections import OrderedDict
+from pathlib import Path
+
+from safetensors.torch import load_file, save_file
+
+
+SIZE_RE = re.compile(r"^(\d+(?:\.\d+)?)\s*([kmgt]?b?)?$", re.I)
+UNIT_MULTIPLIERS = {
+    "": 1,
+    "b": 1,
+    "k": 1000,
+    "kb": 1000,
+    "m": 1000**2,
+    "mb": 1000**2,
+    "g": 1000**3,
+    "gb": 1000**3,
+    "t": 1000**4,
+    "tb": 1000**4,
+}
+
+
+def parse_size(value: str) -> int:
+    match = SIZE_RE.match(value.strip())
+    if not match:
+        raise ValueError(f"invalid size: {value!r}")
+    number = float(match.group(1))
+    unit = (match.group(2) or "").lower()
+    return int(number * UNIT_MULTIPLIERS[unit])
+
+
+def tensor_nbytes(tensor) -> int:
+    return tensor.numel() * tensor.element_size()
+
+
+def shard_state_dict(state: dict, max_shard_size: int, weights_name: str):
+    shards: list[OrderedDict] = []
+    current = OrderedDict()
+    current_size = 0
+    weight_map = {}
+    total_size = 0
+
+    def flush() -> None:
+        nonlocal current, current_size
+        if current:
+            shards.append(current)
+            current = OrderedDict()
+            current_size = 0
+
+    for name, tensor in state.items():
+        size = tensor_nbytes(tensor)
+        total_size += size
+        if current and current_size + size > max_shard_size:
+            flush()
+        current[name] = tensor
+        current_size += size
+
+    flush()
+
+    total_shards = len(shards)
+    shard_files = OrderedDict()
+    stem = weights_name.removesuffix(".safetensors")
+    for idx, shard in enumerate(shards, start=1):
+        filename = f"{stem}-{idx:05d}-of-{total_shards:05d}.safetensors"
+        shard_files[filename] = shard
+        for weight_name in shard:
+            weight_map[weight_name] = filename
+
+    index = {
+        "metadata": {"total_size": total_size},
+        "weight_map": weight_map,
+    }
+    return shard_files, index
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--model-dir",
+        default="/root/models/teutonic-5gbdp8ba-test-dv00",
+        help="Directory containing model.safetensors.",
+    )
+    parser.add_argument("--input", default="model.safetensors")
+    parser.add_argument("--max-shard-size", default="4GB")
+    parser.add_argument("--delete-original", action="store_true")
+    parser.add_argument("--overwrite", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    model_dir = Path(args.model_dir).expanduser().resolve()
+    src = model_dir / args.input
+    if not src.exists():
+        raise FileNotFoundError(src)
+
+    max_shard_size = parse_size(args.max_shard_size)
+    existing = sorted(model_dir.glob("model-*-of-*.safetensors"))
+    index_path = model_dir / "model.safetensors.index.json"
+    if (existing or index_path.exists()) and not args.overwrite:
+        raise RuntimeError(
+            "shards/index already exist; pass --overwrite if you really want to rewrite them"
+        )
+
+    print(f"loading {src}")
+    state = load_file(str(src), device="cpu")
+    print(f"loaded {len(state)} tensors; max_shard_size={max_shard_size} bytes")
+
+    shard_files, index = shard_state_dict(state, max_shard_size, "model.safetensors")
+    print(f"writing {len(shard_files)} shard(s)")
+    for filename, shard in shard_files.items():
+        out = model_dir / filename
+        print(f"  {filename}: {len(shard)} tensor(s)")
+        save_file(shard, str(out), metadata={"format": "pt"})
+
+    index_path.write_text(json.dumps(index, indent=2, sort_keys=True))
+    print(f"wrote {index_path}")
+
+    if args.delete_original:
+        src.unlink()
+        print(f"deleted {src}")
+    else:
+        print(f"kept original {src}; delete it after verifying the shards")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/write_king_ref.py
+++ b/scripts/write_king_ref.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""
+Recover the current king snapshot path and write it to MODEL_CACHE_DIR/.current_king.
+
+Sources tried in order:
+  1. GET /health on the live eval server — returns the king currently in GPU memory
+     (primary: always accurate, even for in-progress evals)
+  2. Eval JSON records — fallback when the server is unreachable
+
+Run this once when the eval server was started before the .current_king file was
+introduced (or after the file was lost). After this, the eval server writes the
+file itself on every new king load via ensure_king().
+
+Usage:
+    python scripts/write_king_ref.py
+    python scripts/write_king_ref.py --dry-run
+    python scripts/write_king_ref.py --eval-server http://localhost:9000
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+log = logging.getLogger("write_king_ref")
+
+DEFAULT_CACHE_DIR = Path(os.environ.get("TEUTONIC_MODEL_CACHE_DIR", "/tmp/teutonic/quasar_pair_models"))
+DEFAULT_RECORD_DIR = Path(os.environ.get("TEUTONIC_EVAL_RECORD_DIR", "/tmp/teutonic/quasar_pair_evals"))
+DEFAULT_EVAL_SERVER = os.environ.get("TEUTONIC_EVAL_SERVER", "http://localhost:9000")
+
+
+def setup_logging() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s  %(message)s", datefmt="%H:%M:%S")
+
+
+# ---------------------------------------------------------------------------
+# Source 1: live eval server /health endpoint
+# ---------------------------------------------------------------------------
+
+def king_path_from_server(server_url: str, cache_dir: Path) -> str | None:
+    """
+    Query GET /health and reconstruct the king snapshot path from king_loaded.
+
+    king_loaded is the _king_key tuple: [repo, digest_or_latest, config_source].
+    The snapshot dir follows the same convention as materialize_model():
+        cache_dir / repo.replace("/", "--") / digest.replace(":", "-")
+    """
+    url = server_url.rstrip("/") + "/health"
+    try:
+        with urllib.request.urlopen(url, timeout=5) as resp:
+            data = json.loads(resp.read())
+    except Exception as exc:
+        log.warning("could not reach eval server at %s: %s", url, exc)
+        return None
+
+    king_key = data.get("king_loaded")
+    if not king_key:
+        log.info("eval server reachable but king_loaded is null (no king loaded yet)")
+        return None
+
+    # king_key is [repo, digest_or_latest, config_source]
+    try:
+        repo, digest, _config_source = king_key
+    except (TypeError, ValueError) as exc:
+        log.warning("unexpected king_loaded format %r: %s", king_key, exc)
+        return None
+
+    digest_dir = digest.replace(":", "-") if digest and digest != "latest" else "latest"
+    snapshot = cache_dir / repo.replace("/", "--") / digest_dir
+
+    log.info("eval server reports current king:")
+    log.info("  king_repo   : %s", repo)
+    log.info("  king_digest : %s", digest)
+    log.info("  snapshot    : %s", snapshot)
+
+    if not snapshot.exists():
+        log.warning("king snapshot dir does not exist on disk: %s", snapshot)
+        log.warning("the server has it in GPU memory but disk files may have been deleted")
+        # Still return it — writing the ref is the right thing so cleanup skips it
+        return str(snapshot.resolve())
+
+    return str(snapshot.resolve())
+
+
+# ---------------------------------------------------------------------------
+# Source 2: completed eval JSON records (fallback)
+# ---------------------------------------------------------------------------
+
+def king_path_from_records(record_dir: Path) -> tuple[str, Path] | None:
+    """
+    Scan eval record JSONs (newest first) and return the first valid king
+    snapshot path found, together with the record file it came from.
+
+    Record filenames are prefixed with %Y%m%dT%H%M%SZ so lexicographic sort
+    gives chronological order. Only completed evals write records, so an
+    in-progress eval whose king changed since the last record won't be captured
+    here — that's why the live server query is tried first.
+    """
+    records = sorted(record_dir.glob("*.json"), reverse=True)
+    if not records:
+        log.error("no eval record JSON files found in %s", record_dir)
+        return None
+
+    log.info("found %d eval record(s), scanning newest first", len(records))
+
+    for record_file in records:
+        try:
+            data = json.loads(record_file.read_text())
+        except Exception as exc:
+            log.warning("skipping %s (parse error: %s)", record_file.name, exc)
+            continue
+
+        verdict = data.get("verdict") or {}
+        king_path_str = (verdict.get("model_artifacts") or {}).get("king", {}).get("path", "")
+
+        if not king_path_str:
+            log.warning("skipping %s (no model_artifacts.king.path)", record_file.name)
+            continue
+
+        king_path = Path(king_path_str)
+        king_repo = verdict.get("king_repo", "?")
+        king_digest = verdict.get("king_digest", "latest")
+
+        if not king_path.exists():
+            log.warning("skipping %s — snapshot no longer on disk: %s", record_file.name, king_path)
+            continue
+
+        log.info("found king in %s", record_file.name)
+        log.info("  king_repo   : %s", king_repo)
+        log.info("  king_digest : %s", king_digest or "latest")
+        log.info("  snapshot    : %s", king_path)
+        return str(king_path.resolve()), record_file
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Write .current_king ref file from the live eval server or eval JSON records.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--cache-dir", type=Path, default=DEFAULT_CACHE_DIR, help="Model cache directory")
+    parser.add_argument("--record-dir", type=Path, default=DEFAULT_RECORD_DIR, help="Eval record directory")
+    parser.add_argument("--eval-server", default=DEFAULT_EVAL_SERVER, help="Eval server base URL for /health query")
+    parser.add_argument("--no-server", action="store_true", help="Skip live server query, use records only")
+    parser.add_argument("--dry-run", action="store_true", help="Print what would be written without writing")
+    args = parser.parse_args()
+
+    setup_logging()
+
+    cache_dir = args.cache_dir.resolve()
+    ref_file = cache_dir / ".current_king"
+    king_path: str | None = None
+    source: str = ""
+
+    # --- Source 1: live server ---
+    if not args.no_server:
+        log.info("querying eval server %s …", args.eval_server)
+        king_path = king_path_from_server(args.eval_server, cache_dir)
+        if king_path:
+            source = f"live server ({args.eval_server}/health)"
+
+    # --- Source 2: records fallback ---
+    if not king_path:
+        record_dir = args.record_dir.resolve()
+        if not record_dir.exists():
+            log.error("record dir does not exist: %s", record_dir)
+            raise SystemExit(1)
+        log.info("falling back to eval records in %s …", record_dir)
+        result = king_path_from_records(record_dir)
+        if result:
+            king_path, record_file = result
+            source = f"eval record ({record_file.name})"
+
+    if not king_path:
+        log.error("could not determine current king from any source")
+        raise SystemExit(1)
+
+    if args.dry_run:
+        log.info("[DRY RUN] would write to %s  (source: %s):", ref_file, source)
+        log.info("  %s", king_path)
+        return
+
+    ref_file.parent.mkdir(parents=True, exist_ok=True)
+    ref_file.write_text(king_path)
+    log.info("wrote %s  (source: %s)", ref_file, source)
+    log.info("  -> %s", king_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/validator.py
+++ b/validator.py
@@ -527,28 +527,16 @@ def _download_code_files(ref: ModelRef, files: set[str]) -> Path:
     target.mkdir(parents=True, exist_ok=True)
 
     allow_patterns = sorted(files)
-    if ref.digest.startswith("hf:"):
-        from huggingface_hub import snapshot_download as hf_snapshot_download
+    from hippius_hub import snapshot_download
 
-        hf_snapshot_download(
-            repo_id=ref.repo,
-            revision=ref.digest[3:],
-            local_dir=str(target),
-            allow_patterns=allow_patterns,
-            max_workers=4,
-            token=os.environ.get("HF_TOKEN") or os.environ.get("HUGGINGFACE_API_KEY"),
-        )
-    else:
-        from hippius_hub import snapshot_download
-
-        snapshot_download(
-            repo_id=ref.repo,
-            revision=ref.digest,
-            local_dir=str(target),
-            allow_patterns=allow_patterns,
-            max_workers=4,
-            token=_resolve_hub_token(f"Downloading code files for {ref.immutable_ref}"),
-        )
+    snapshot_download(
+        repo_id=ref.repo,
+        revision=ref.digest,
+        local_dir=str(target),
+        allow_patterns=allow_patterns,
+        max_workers=4,
+        token=_resolve_hub_token(f"Downloading code files for {ref.immutable_ref}"),
+    )
     return target
 
 


### PR DESCRIPTION
- validator.py: drop huggingface_hub branch in _download_code_files, use hippius_hub only
- ecosystem.cleanup.config.js: PM2 cron jobs for cache cleanup and king-ref writer
- ecosystem.eval.config.js: separate PM2 config for the Quasar pair-eval server
- scripts/cleanup_model_cache.py: prune stale/partial snapshot dirs with safety guards
- scripts/write_king_ref.py: recover and persist current king snapshot path
- scripts/experiments/divide_safetensors.py: experimental safetensors split utility